### PR TITLE
add cross-env to fix build on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
 		"prerender": "node scripts/prerender.js && node src/server/prerender.js && rm src/server/prerender.js",
 		"test": "jest",
 		"start": "rm -rf build && mkdir build && yarn prerender && node scripts/start.js",
-		"build": "rm -rf build && mkdir build && yarn prerender && NODE_ENV=production node scripts/build.js",
+		"build": "rm -rf build && mkdir build && yarn prerender && cross-env NODE_ENV=production node scripts/build.js",
 		"serve": "live-server --host=localhost --port=8080 build"
 	},
 	"dependencies": {
+		"cross-env": "^7.0.3",
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1",
 		"react-router-dom": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,6 +1228,13 @@ cors@latest:
     object-assign "^4"
     vary "^1"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1239,7 +1246,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
A small tweak to make the build script work on Windows. I'm not clear if this is the same use case as addressed by https://github.com/zaydek/react-ssg/issues/23, but in any case this small change makes it work for me